### PR TITLE
feat: add new reset command & clean/prune arguments

### DIFF
--- a/src/applications/amps.ts
+++ b/src/applications/amps.ts
@@ -56,7 +56,6 @@ export class AMPS {
       const nodes = AMPS.getNodes('//*[local-name()=\'packaging\']');
       return nodes.some(item => item.textContent === 'atlassian-plugin');
     } catch (err) {
-      console.log(err);
       return false;
     }
   }

--- a/src/applications/bamboo.ts
+++ b/src/applications/bamboo.ts
@@ -24,7 +24,7 @@ export class Bamboo extends Base {
 
   // ------------------------------------------------------------------------------------------ Protected Methods
 
-  protected getService = (): Service => {
+  protected getService(): Service {
 
     const volumes = this.getVolumes();
     const environment = this.getEnvironmentVariables();

--- a/src/applications/bitbucket.ts
+++ b/src/applications/bitbucket.ts
@@ -22,7 +22,7 @@ export class Bitbucket extends Base {
 
   // ------------------------------------------------------------------------------------------ Protected Methods
 
-  protected getService = (): Service => {
+  protected getService(): Service {
 
     const volumes = this.getVolumes();
     const environment = this.getEnvironmentVariables();

--- a/src/applications/confluence.ts
+++ b/src/applications/confluence.ts
@@ -22,7 +22,7 @@ export class Confluence extends Base {
 
   // ------------------------------------------------------------------------------------------ Protected Methods
 
-  protected getService = (): Service => {
+  protected getService(): Service {
 
     const volumes = this.getVolumes();
     const environment = this.getEnvironmentVariables();

--- a/src/applications/jira.ts
+++ b/src/applications/jira.ts
@@ -22,7 +22,7 @@ export class Jira extends Base {
 
   // ------------------------------------------------------------------------------------------ Protected Methods
 
-  protected getService = (): Service => {
+  protected getService(): Service {
     const volumes = this.getVolumes();
     const environment = this.getEnvironmentVariables();
 

--- a/src/commands/database-mssql.ts
+++ b/src/commands/database-mssql.ts
@@ -12,6 +12,8 @@ import { MSSQL, MSSQLOptions } from '../databases/mssql';
     .addOption(new Option('-e, --edition <edition>', 'The edition of Microsoft SQL Server').choices([ 'Developer', 'Express', 'Standard', 'Enterprise', 'EnterpriseCore' ]).default('Developer'))
     .addOption(new Option('-p, --port <port>', 'The port on which the database will be accessible').default('1433'))
     .addOption(new Option('-P, --password <password>', 'The value passed to MSSQL_SA_PASSWORD environment variable. MS SQL Server password policy applies.').default('DataCenterDX!'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .parse(process.argv)
     .opts();
 
@@ -20,6 +22,8 @@ import { MSSQL, MSSQLOptions } from '../databases/mssql';
     edition: options.edition,
     port: Number(options.port),
     password: options.password,
+    clean: options.clean,
+    prune: options.prune,
     logging: true
   } as MSSQLOptions);
 

--- a/src/commands/database-mysql.ts
+++ b/src/commands/database-mysql.ts
@@ -13,6 +13,8 @@ import { MySQL } from '../databases/mysql';
     .addOption(new Option('-p, --port <port>', 'The port on which the database will be accessible').default('3306'))
     .addOption(new Option('-U, --username <username>', 'The value passed to MYSQL_USER environment variable').default('dcdx'))
     .addOption(new Option('-P, --password <password>', 'The value passed to MYSQL_PASSWORD environment variable').default('dcdx'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .parse(process.argv)
     .opts();
 
@@ -22,6 +24,8 @@ import { MySQL } from '../databases/mysql';
     port: Number(options.port),
     username: options.username,
     password: options.password,
+    clean: options.clean,
+    prune: options.prune,
     logging: true
   });
 

--- a/src/commands/database-postgres.ts
+++ b/src/commands/database-postgres.ts
@@ -13,6 +13,8 @@ import { Postgres } from '../databases/postgres';
     .addOption(new Option('-p, --port <port>', 'The port on which the database will be accessible').default('5432'))
     .addOption(new Option('-U, --username <username>', 'The value passed to POSTGRES_USER environment variable').default('dcdx'))
     .addOption(new Option('-P, --password <password>', 'The value passed to POSTGRES_PASSWORD environment variable').default('dcdx'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .parse(process.argv)
     .opts();
 
@@ -22,6 +24,8 @@ import { Postgres } from '../databases/postgres';
     port: Number(options.port),
     username: options.username,
     password: options.password,
+    clean: options.clean,
+    prune: options.prune,
     logging: true
   })
 

--- a/src/commands/reset-bamboo.ts
+++ b/src/commands/reset-bamboo.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { Option, program } from 'commander';
+import { gracefulExit } from 'exit-hook';
+
+import { AMPS } from '../applications/amps';
+import { Bamboo } from '../applications/bamboo';
+
+const version = AMPS.getApplicationVersion() || '9.6.1';
+
+(async () => {
+  const options = program
+    .showHelpAfterError(true)
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '9.4.3' ]).default(version))
+    .addOption(new Option('-d, --database <name>', 'The database engine to remove data from').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
+    .parse(process.argv)
+    .opts();
+
+  const instance = new Bamboo({
+    version: options.version,
+    database: options.database
+  });
+
+  await instance.reset();
+})();
+
+process.on('SIGINT', () => {
+  console.log(`Received term signal, trying to stop gracefully 💪`);
+  gracefulExit();
+});

--- a/src/commands/reset-bitbucket.ts
+++ b/src/commands/reset-bitbucket.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { Option, program } from 'commander';
+import { gracefulExit } from 'exit-hook';
+
+import { AMPS } from '../applications/amps';
+import { Bitbucket } from '../applications/bitbucket';
+
+const version = AMPS.getApplicationVersion() || '9.4.3';
+
+(async () => {
+  const options = program
+    .showHelpAfterError(true)
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '9.4.3' ]).default(version))
+    .addOption(new Option('-d, --database <name>', 'The database engine to remove data from').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
+    .parse(process.argv)
+    .opts();
+
+  const instance = new Bitbucket({
+    version: options.version,
+    database: options.database
+  });
+
+  await instance.reset();
+})();
+
+process.on('SIGINT', () => {
+  console.log(`Received term signal, trying to stop gracefully 💪`);
+  gracefulExit();
+});

--- a/src/commands/reset-confluence.ts
+++ b/src/commands/reset-confluence.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { Option, program } from 'commander';
+import { gracefulExit } from 'exit-hook';
+
+import { AMPS } from '../applications/amps';
+import { Confluence } from '../applications/confluence';
+
+const version = AMPS.getApplicationVersion() || '8.9.0';
+
+(async () => {
+  const options = program
+    .showHelpAfterError(true)
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '8.9.0' ]).default(version))
+    .addOption(new Option('-d, --database <name>', 'The database engine to remove data from').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
+    .parse(process.argv)
+    .opts();
+
+  const instance = new Confluence({
+    version: options.version,
+    database: options.database
+  });
+
+  await instance.reset();
+})();
+
+process.on('SIGINT', () => {
+  console.log(`Received term signal, trying to stop gracefully 💪`);
+  gracefulExit();
+});

--- a/src/commands/reset-jira.ts
+++ b/src/commands/reset-jira.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { Option, program } from 'commander';
+import { gracefulExit } from 'exit-hook';
+
+import { AMPS } from '../applications/amps';
+import { Jira } from '../applications/jira';
+
+const version = AMPS.getApplicationVersion() || '9.15.0';
+
+(async () => {
+  const options = program
+    .showHelpAfterError(true)
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '9.15.0' ]).default(version))
+    .addOption(new Option('-d, --database <name>', 'The database engine to remove data from').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
+    .parse(process.argv)
+    .opts();
+
+  const instance = new Jira({
+    version: options.version,
+    database: options.database,
+  });
+
+  await instance.reset();
+})();
+
+process.on('SIGINT', () => {
+  console.log(`Received term signal, trying to stop gracefully 💪`);
+  gracefulExit();
+});

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -17,12 +17,12 @@ if (isDefaultCommand) {
 }
 
 program
-  .name('dcdx run')
+  .name('dcdx reset')
   .addOption(new Option('-P, --activate-profiles <arg>', 'Comma-delimited list of profiles to activate'))
-  .command('bamboo', 'Start Atlassian Bamboo (standalone)', { executableFile: './run-bamboo.js'})
-  .command('bitbucket', 'Start Atlassian Bitbucket (standalone)', { executableFile: './run-bitbucket.js'})
-  .command('confluence', 'Start Atlassian Confluence (standalone)', { executableFile: './run-confluence.js'})
-  .command('jira', 'Start Atlassian Jira (standalone)', { executableFile: './run-jira.js'})
+  .command('bamboo', 'Remove all data (incl. database) for Atlassian Bamboo (standalone)', { executableFile: './reset-bamboo.js'})
+  .command('bitbucket', 'Remove all data (incl. database) for Atlassian Bitbucket (standalone)', { executableFile: './reset-bitbucket.js'})
+  .command('confluence', 'Remove all data (incl. database) for Atlassian Confluence (standalone)', { executableFile: './reset-confluence.js'})
+  .command('jira', 'Remove all data (incl. database) for Atlassian Jira (standalone)', { executableFile: './reset-jira.js'})
   .showHelpAfterError(true);
 
 program.parse(process.argv);

--- a/src/commands/run-bamboo.ts
+++ b/src/commands/run-bamboo.ts
@@ -8,11 +8,13 @@ import { Bamboo } from '../applications/bamboo';
 (async () => {
   const options = program
     .showHelpAfterError(true)
-    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '9.4.3' ]).default('9.4.3'))
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '9.4.3' ]).default('9.6.1'))
     .addOption(new Option('-d, --database <name>', 'The database engine on which the host application will run').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
     .addOption(new Option('-p, --port <port>', 'The HTTP port on which the host application will be accessible').default('80'))
     .addOption(new Option('-c, --contextPath <contextPath>', 'The context path on which the host application will be accessible'))
     .addOption(new Option('-qr, --quickReload <path_to_watch>', 'Add support for QuickReload and add the provided path to the watch list'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .addOption(new Option('--debug', 'Add support for JVM debugger on port 5005'))
     .parse(process.argv)
     .opts();
@@ -23,6 +25,8 @@ import { Bamboo } from '../applications/bamboo';
     port: Number(options.port),
     contextPath: options.contextPath,
     quickReload: options.qr,
+    clean: options.clean,
+    prune: options.prune,
     debug: options.debug
   });
 

--- a/src/commands/run-bitbucket.ts
+++ b/src/commands/run-bitbucket.ts
@@ -8,10 +8,12 @@ import { Bitbucket } from '../applications/bitbucket';
 (async () => {
   const options = program
     .showHelpAfterError(true)
-    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '8.9.0' ]).default('8.9.0'))
+    .addOption(new Option('-v, --version <version>', 'The version of the host application').choices([ '8.19.1' ]).default('8.19.1'))
     .addOption(new Option('-d, --database <name>', 'The database engine on which the host application will run').choices([ 'postgresql', 'mysql', 'mssql' ]).default('postgresql'))
     .addOption(new Option('-p, --port <port>', 'The HTTP port on which the host application will be accessible').default('80'))
     .addOption(new Option('-qr, --quickReload <path_to_watch>', 'Add support for QuickReload and add the provided path to the watch list'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .addOption(new Option('--debug', 'Add support for JVM debugger on port 5005'))
     .parse(process.argv)
     .opts();
@@ -21,6 +23,8 @@ import { Bitbucket } from '../applications/bitbucket';
     database: options.database,
     port: Number(options.port),
     quickReload: options.qr,
+    clean: options.clean,
+    prune: options.prune,
     debug: options.debug
   });
 

--- a/src/commands/run-confluence.ts
+++ b/src/commands/run-confluence.ts
@@ -13,6 +13,8 @@ import { Confluence } from '../applications/confluence';
     .addOption(new Option('-p, --port <port>', 'The HTTP port on which the host application will be accessible').default('80'))
     .addOption(new Option('-c, --contextPath <contextPath>', 'The context path on which the host application will be accessible'))
     .addOption(new Option('-qr, --quickReload <path_to_watch>', 'Add support for QuickReload and add the provided path to the watch list'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .addOption(new Option('--debug', 'Add support for JVM debugger on port 5005'))
     .parse(process.argv)
     .opts();
@@ -23,6 +25,8 @@ import { Confluence } from '../applications/confluence';
     port: Number(options.port),
     contextPath: options.contextPath,
     quickReload: options.qr,
+    clean: options.clean,
+    prune: options.prune,
     debug: options.debug
   });
 

--- a/src/commands/run-jira.ts
+++ b/src/commands/run-jira.ts
@@ -13,6 +13,8 @@ import { Jira } from '../applications/jira';
     .addOption(new Option('-p, --port <port>', 'The HTTP port on which the host application will be accessible').default('80'))
     .addOption(new Option('-c, --contextPath <contextPath>', 'The context path on which the host application will be accessible'))
     .addOption(new Option('-qr, --quickReload <path_to_watch>', 'Add support for QuickReload and add the provided path to the watch list'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .addOption(new Option('--debug', 'Add support for JVM debugger on port 5005'))
     .parse(process.argv)
     .opts();
@@ -23,6 +25,8 @@ import { Jira } from '../applications/jira';
     port: Number(options.port),
     contextPath: options.contextPath,
     quickReload: options.qr,
+    clean: options.clean,
+    prune: options.prune,
     debug: options.debug
   });
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -41,6 +41,8 @@ const version = AMPS.getApplicationVersion();
     .addOption(new Option('-c, --contextPath <contextPath>', 'The context path on which the host application will be accessible'))
     .addOption(new Option('-P, --activate-profiles <arg>', 'Comma-delimited list of profiles to activate'))
     .addOption(new Option('-o, --outputDirectory <arg>', 'Output directory where QuickReload will look for generated JAR files').default('target'))
+    .addOption(new Option('--clean', 'Remove data files before starting the database').default(false))
+    .addOption(new Option('--prune', 'Remove data files when stopping the database').default(false))
     .addOption(new Option('--debug', 'Add support for JVM debugger on port 5005').default(true))
     .allowUnknownOption(true)
     .parse(process.argv)
@@ -51,6 +53,8 @@ const version = AMPS.getApplicationVersion();
     database: options.database,
     port: Number(options.port),
     contextPath: options.contextPath,
+    clean: options.clean,
+    prune: options.prune,
     debug: options.debug
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,12 @@ program
   .version(pkg.version)
   .showHelpAfterError(true);
 
-// ------------------------------------------------------------------------------------------ Run
+// ------------------------------------------------------------------------------------------ Start
 
 program
   .command('start', 'Build & install the Atlassian Data Center plugin from the current directory', { executableFile: './commands/start.js' });
+
+// ------------------------------------------------------------------------------------------ Run
 
 program
   .command('run', 'Start the Atlassian host application (standalone)', { executableFile: './commands/run.js' });
@@ -86,6 +88,11 @@ program
     process.argv.splice(2, 1, ...[ 'database', 'mssql' ]);
     program.parse(process.argv);
   });
+
+// ------------------------------------------------------------------------------------------ Reset
+
+program
+  .command('reset', 'Remove all application data (incl. database) and start fresh!', { executableFile: './commands/reset.js' });
 
 // ------------------------------------------------------------------------------------------ Profile
 

--- a/src/types/ApplicationOptions.ts
+++ b/src/types/ApplicationOptions.ts
@@ -3,9 +3,11 @@ import { SupportedDatabaseEngines } from './SupportedDatabaseEngines';
 export type ApplicationOptions = {
   version: string;
   database: SupportedDatabaseEngines;
-  port: number;
+  port?: number;
   contextPath?: string;
   quickReload?: boolean;
   license?: string;
+  clean?: boolean;
+  prune?: boolean;
   debug?: boolean;
 }

--- a/src/types/DatabaseEngine.ts
+++ b/src/types/DatabaseEngine.ts
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 
 import { DatabaseOptions } from './DatabaseOptions';
-import { SupportedApplications } from './SupportedApplications';
 import { SupportedDatabaseDrivers } from './SupportedDatabaseDrivers';
 import { SupportedDatabaseEngines } from './SupportedDatabaseEngines';
 
@@ -10,8 +9,7 @@ export interface DatabaseEngine extends EventEmitter {
   url: string;
   driver: SupportedDatabaseDrivers;
   options: DatabaseOptions;
-  start(): Promise<void>;
-  start(application: SupportedApplications, version: string): Promise<void>;
-  stop(): Promise<void>;
+  start(clean?: boolean): Promise<void>;
+  stop(prune?: boolean): Promise<void>;
   run(sql: string | { query: string; values: unknown[] }): Promise<[unknown[], unknown]|null>;
 }

--- a/src/types/DatabaseOptions.ts
+++ b/src/types/DatabaseOptions.ts
@@ -5,5 +5,7 @@ export type DatabaseOptions = {
   database: string;
   username: string;
   password: string;
+  clean?: boolean;
+  prune?: boolean;
   logging?: boolean;
 }


### PR DESCRIPTION
The reset command allows you to delete all Atlassian host product data, which will now be persisted unless you use the new clean/prune options